### PR TITLE
Error message for non-writable output file

### DIFF
--- a/bin/nanook_split_fasta
+++ b/bin/nanook_split_fasta
@@ -63,7 +63,7 @@ while(<INPUTFILE>) {
                 print "\r$count";
             }
             
-            open($fh, ">".$out_filename);
+            open($fh, ">".$out_filename) or die "Can't open output ".$out_filename."\n";
         } else {
             print "WARNING: Repeat ID $id\n";
         }


### PR DESCRIPTION
When using the nanook_split_fasta script with an ouput folder that is not writable (or does not exist) there was a "print() on closed filehandle $fh" error message. I added a little error message to make the problem more easy to understand.